### PR TITLE
release 0.12 for Chicken Scheme 5

### DIFF
--- a/clucker.release-info.5
+++ b/clucker.release-info.5
@@ -2,3 +2,4 @@
 (repo git "git://github.com/n3mo/{egg-name}.git")
 (uri targz "https://github.com/n3mo/{egg-name}/tarball/{egg-release}")
 (release "0.11")
+(release "0.12")


### PR DESCRIPTION
Updating the egg for Chicken Scheme 5 was overlooked in commit  e36bbe6, causing n3mo/massmine to fail since v1.2.1.